### PR TITLE
Use webdriver-manager for Chrome driver initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -304,7 +306,9 @@ options.add_argument(
     "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
 )
 options.add_argument("--disable-blink-features=AutomationControlled")
-driver = webdriver.Chrome(options=options)
+driver = webdriver.Chrome(
+    service=Service(ChromeDriverManager().install()), options=options
+)
 time.sleep(5)
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 SQLAlchemy
 google-generativeai
 psycopg2-binary
+webdriver-manager


### PR DESCRIPTION
## Summary
- Add `webdriver-manager` dependency to simplify ChromeDriver management.
- Initialize Chrome WebDriver using `ChromeDriverManager` to avoid manual driver downloads and PATH issues.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b9ca614808320adbfe57ac85b56fa